### PR TITLE
Production deploy blockers: tsc build + CORS hardening

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "serve": "ts-node-dev --respawn --transpile-only src/main.ts",
-    "start": "node dist/main.js",
+    "start": "node dist/apps/api/src/main.js",
     "test": "jest --passWithNoTests",
     "test:integration": "RUN_DB_INTEGRATION_TESTS=1 DATABASE_URL=postgresql://ticketbot:ticketbot@localhost:5433/ticketbot_test jest --testPathPattern='membership-constraints' --runInBand",
     "test:e2e": "jest --config jest-e2e.config.ts --runInBand",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -16,15 +16,23 @@ async function bootstrap() {
 
   app.enableShutdownHooks();
 
+  const webUrl = config.get<string>('webUrl');
+  const nodeEnv = config.get<string>('nodeEnv');
+  const isProd = nodeEnv === 'production';
+
   app.enableCors({
     origin: (origin, callback) => {
-      // Allow all origins in development or matching webUrl
-      callback(null, true);
+      // Same-origin / server-to-server requests have no Origin header
+      if (!origin) return callback(null, true);
+      if (isProd) {
+        if (origin === webUrl) return callback(null, true);
+        return callback(new Error(`CORS: origin ${origin} not allowed`), false);
+      }
+      return callback(null, true);
     },
     credentials: true,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     allowedHeaders: 'Content-Type, Accept, Authorization, x-association-id, ngrok-skip-browser-warning',
-
   });
 
   app.setGlobalPrefix('api/v1');
@@ -47,7 +55,6 @@ async function bootstrap() {
   // polling mode instead — registering a webhook here would cancel
   // that mode silently and break /start, /link in dev.
   const apiUrl = config.get<string>('apiUrl');
-  const nodeEnv = config.get<string>('nodeEnv');
   const isPublicApiUrl =
     !!apiUrl &&
     !apiUrl.includes('localhost') &&

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false
+    "noEmit": false,
+    "declaration": false,
+    "declarationMap": false
   },
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- **`fix(api): unblock production tsc build`** — `pnpm --filter api build` was failing with TS6059 (path-aliased libs outside `rootDir`) and TS2742 (Prisma runtime type names not portable). Drop `rootDir` and disable `.d.ts` emit; bump `start` to the new emit path. Dev mode (`ts-node-dev --transpile-only`) was masking these errors.
- **`feat(api): tighten CORS in production`** — In `NODE_ENV=production`, only requests with `Origin === WEB_URL` (or no Origin header — server-to-server) are accepted; others rejected with a CORS error. Dev/test keep the previous permissive behavior.

## Test plan
- [x] `pnpm --filter api build` succeeds locally; emits `dist/apps/api/src/main.js`
- [ ] Pull, run `pnpm dev:api`, confirm dev still boots and CORS still allows the local web app
- [ ] In production, set `WEB_URL` to the deployed web origin and verify cross-origin requests from any other domain are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)