### PR TITLE
chore(db): single env source — Prisma reads from apps/api/.env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out/
 .env
 .env.local
 .env.*.local
+.env.dev
 
 # IDE
 .idea/

--- a/libs/database/.env.example
+++ b/libs/database/.env.example
@@ -1,9 +1,13 @@
-# Database environment — copy to libs/database/.env and fill in.
-# Used by Prisma CLI (`pnpm db:migrate`, `pnpm db:generate`, etc.).
-# Mirrors apps/api/.env's DATABASE_URL but is loaded directly by Prisma.
-
+# NO ENV FILE NEEDED HERE.
+#
+# Prisma CLI is wired to read `apps/api/.env` via dotenv-cli — see the
+# root `package.json` `db:*` scripts. Put DATABASE_URL in `apps/api/.env`
+# only. This file exists just as a signpost so nobody recreates a second
+# .env here by accident.
+#
 # Local dev: docker-compose maps Postgres to 5433
-# Production migrations: use Supabase DIRECT connection URL (NOT the pooler)
-# - Pooler URL is for runtime (apps/api/.env)
+#   DATABASE_URL="postgresql://ticketbot:ticketbot@localhost:5433/ticketbot?schema=public"
+#
+# Production migrations: use Supabase DIRECT URL (port 5432, NOT the 6543 pooler)
+# - Pooler URL is for runtime (set in Railway env vars)
 # - Direct URL is for migrations to allow advisory locks
-DATABASE_URL="postgresql://ticketbot:ticketbot@localhost:5433/ticketbot?schema=public"

--- a/package.json
+++ b/package.json
@@ -11,16 +11,18 @@
     "dev:bot": "nx run bot:serve",
     "dev:web": "nx run web:dev",
     "dev": "nx run-many -t serve dev --parallel=3",
-    "db:generate": "pnpm --filter @ticketbot/database exec prisma generate",
-    "db:migrate": "pnpm --filter @ticketbot/database exec prisma migrate dev",
-    "db:seed": "pnpm --filter @ticketbot/database exec prisma db seed",
-    "db:studio": "pnpm --filter @ticketbot/database exec prisma studio",
-    "db:dev-reset": "pnpm --filter @ticketbot/database exec tsx prisma/dev-reset.ts"
+    "db:generate": "dotenv -e apps/api/.env -- pnpm --filter @ticketbot/database exec prisma generate",
+    "db:migrate": "dotenv -e apps/api/.env -- pnpm --filter @ticketbot/database exec prisma migrate dev",
+    "db:migrate:deploy": "dotenv -e apps/api/.env -- pnpm --filter @ticketbot/database exec prisma migrate deploy",
+    "db:seed": "dotenv -e apps/api/.env -- pnpm --filter @ticketbot/database exec prisma db seed",
+    "db:studio": "dotenv -e apps/api/.env -- pnpm --filter @ticketbot/database exec prisma studio",
+    "db:dev-reset": "dotenv -e apps/api/.env -- pnpm --filter @ticketbot/database exec tsx prisma/dev-reset.ts"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^9.0.0",
     "nx": "^22.6.5",
     "prettier": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.0.0
         version: 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      dotenv-cli:
+        specifier: ^11.0.0
+        version: 11.0.0
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
@@ -3166,6 +3169,10 @@ packages:
 
   dompurify@3.4.2:
     resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+
+  dotenv-cli@11.0.0:
+    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
+    hasBin: true
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -8275,6 +8282,13 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
     optional: true
+
+  dotenv-cli@11.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 17.4.1
+      dotenv-expand: 12.0.3
+      minimist: 1.2.8
 
   dotenv-expand@11.0.7:
     dependencies:


### PR DESCRIPTION
## Summary
Wire `pnpm db:*` through `dotenv-cli` to load `DATABASE_URL` from `apps/api/.env` only — no more two-file sync between `apps/api/.env` and `libs/database/.env`.

- Add `dotenv-cli` as root devDep
- Prepend `dotenv -e apps/api/.env --` to all `db:*` scripts
- Add `db:migrate:deploy` (prod-safe variant)
- Repurpose `libs/database/.env.example` as a signpost
- Ignore `.env.dev` (per-env backup files devs swap into `.env`)

## Test plan
- [x] `npx dotenv -e apps/api/.env -- node -e ...` confirms env loads
- [ ] After merge: `pnpm db:generate` runs without prompting for DATABASE_URL
- [ ] Devs delete their local `libs/database/.env` (no longer used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)