### PR TITLE
fix(deploy): make workspace package mains resolvable in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,30 @@ RUN pnpm install --frozen-lockfile
 # Generate Prisma client (no DB connection needed here; just reads schema.prisma)
 RUN pnpm --filter @ticketbot/database exec prisma generate
 
-# Compile the API (tsc pulls libs + bot in via path aliases; output lands in dist/apps/api/src/)
+# Compile the bot first — api imports it as a plain package (`bot`, not a path
+# alias), so api's tsc needs `apps/bot/dist/index.d.ts` to resolve the type.
+RUN pnpm --filter bot build
+
+# Flatten the bot dist: tsc infers rootDir = repo root (because path-aliased libs
+# pull files in), so bot's emit lands at apps/bot/dist/apps/bot/src/*. Bring those
+# files up to apps/bot/dist/* so package.json `main: "./dist/index.js"` resolves.
+RUN if [ -d apps/bot/dist/apps/bot/src ]; then \
+      cp -r apps/bot/dist/apps/bot/src/. apps/bot/dist/; \
+    fi
+
+# Compile the API (tsc pulls libs in via path aliases; output lands in dist/apps/api/src/
+# for api and dist/libs/<x>/src/ for each lib).
 RUN pnpm --filter api build
+
+# Each workspace package's `main` points to `./dist/index.js`. Copy the compiled
+# lib output from api's dist into each lib's own dist so Node module resolution
+# (pnpm symlink → package.json main → dist/index.js) finds a real file at runtime.
+RUN for pkg in database ai shared-types shared-validation; do \
+      if [ -d "apps/api/dist/libs/$pkg/src" ]; then \
+        mkdir -p "libs/$pkg/dist" && \
+        cp -r "apps/api/dist/libs/$pkg/src/." "libs/$pkg/dist/"; \
+      fi; \
+    done
 
 ENV NODE_ENV=production
 EXPOSE 3000

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -8,8 +8,8 @@
     "test": "jest --passWithNoTests",
     "lint": "eslint src/"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "dependencies": {
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.0",
@@ -17,6 +17,7 @@
     "reflect-metadata": "^0.2.0",
     "@ticketbot/database": "workspace:*",
     "@ticketbot/shared-types": "workspace:*",
+    "@ticketbot/shared-validation": "workspace:*",
     "@ticketbot/core": "workspace:*"
   },
   "devDependencies": {

--- a/libs/ai/package.json
+++ b/libs/ai/package.json
@@ -2,8 +2,8 @@
   "name": "@ticketbot/ai",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "jest --passWithNoTests",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -2,8 +2,8 @@
   "name": "@ticketbot/core",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint src/"

--- a/libs/database/package.json
+++ b/libs/database/package.json
@@ -2,8 +2,8 @@
   "name": "@ticketbot/database",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint src/"

--- a/libs/shared-types/package.json
+++ b/libs/shared-types/package.json
@@ -2,8 +2,8 @@
   "name": "@ticketbot/shared-types",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint src/"

--- a/libs/shared-validation/package.json
+++ b/libs/shared-validation/package.json
@@ -2,8 +2,8 @@
   "name": "@ticketbot/shared-validation",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint src/",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@ticketbot/shared-types':
         specifier: workspace:*
         version: link:../../libs/shared-types
+      '@ticketbot/shared-validation':
+        specifier: workspace:*
+        version: link:../../libs/shared-validation
       reflect-metadata:
         specifier: ^0.2.0
         version: 0.2.2


### PR DESCRIPTION
## Problem
Railway deploy crashes with `ERR_MODULE_NOT_FOUND: Cannot find module '/app/libs/database/src/prisma-client' imported from /app/libs/database/src/index.ts`. Vanilla node can't load TypeScript, but every workspace package has `main: "./src/index.ts"`. Local dev hides this because ts-node-dev and Next.js' transpilePackages resolve via tsconfig path aliases.

## Fix
- 6 package.jsons: `main` → `./dist/index.js`, `types` → `./dist/index.d.ts`
- `apps/bot/package.json`: add missing `@ticketbot/shared-validation` dep (bot source uses it but only path alias was masking the omission in dev)
- `Dockerfile`:
  - Build bot before api (api's tsc needs bot's `dist/index.d.ts`)
  - Flatten `apps/bot/dist/apps/bot/src/*` → `apps/bot/dist/*` (rootDir inferred = repo root)
  - Copy `apps/api/dist/libs/<x>/src/*` → `libs/<x>/dist/*` for pnpm symlink resolution

## Verification
- [x] Fresh `docker build` succeeds locally
- [x] Container has every expected `dist/index.js`
- [x] Loading `main.js` reaches NestJS env validation stage (proves all require chains resolve)

## Dev note
Local `pnpm dev:web` now needs `pnpm -r build` once after pulling. `pnpm dev:api` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)