### PR TITLE
fix(jobs): make BullMQ connection Upstash-compatible

### DIFF
--- a/apps/api/src/modules/jobs/jobs.module.ts
+++ b/apps/api/src/modules/jobs/jobs.module.ts
@@ -16,12 +16,21 @@ export { TASK_REMINDERS_QUEUE, EVENT_REMINDERS_QUEUE };
       inject: [ConfigService],
       useFactory: (config: ConfigService) => {
         const url = new URL(config.get<string>('redis.url')!);
+        const isTls = url.protocol === 'rediss:';
         return {
           connection: {
             host: url.hostname,
             port: Number(url.port || 6379),
             username: url.username || undefined,
-            password: url.password || undefined,
+            password: url.password
+              ? decodeURIComponent(url.password)
+              : undefined,
+            // BullMQ + Upstash requirements: null retries so blocking
+            // commands don't bail, no ready check since Upstash limits INFO.
+            maxRetriesPerRequest: null,
+            enableReadyCheck: false,
+            // TLS for `rediss://` URLs (Upstash defaults to TLS).
+            ...(isTls ? { tls: { servername: url.hostname } } : {}),
           },
         };
       },


### PR DESCRIPTION
Adds TLS + BullMQ-required ioredis options to JobsModule connection factory. Fixes EPIPE/ECONNRESET storm on Railway with Upstash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)