### PR TITLE
fix(web): skip prerender on auth pages using useSearchParams

### DIFF
--- a/apps/web/src/app/(auth)/callback-magic/page.tsx
+++ b/apps/web/src/app/(auth)/callback-magic/page.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+// Next.js 15 prerender rejects `useSearchParams()` in a Client Component
+// unless wrapped in <Suspense>. This callback depends on URL hash + search
+// params and always runs in the browser, so skip static prerender entirely.
+export const dynamic = 'force-dynamic';
+
 import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '../../../lib/supabase/client';

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+// Next.js 15 prerender rejects `useSearchParams()` in a Client Component
+// unless wrapped in <Suspense>. Login reads `?error=` and `?next=` from
+// the URL, so skip static prerender entirely.
+export const dynamic = 'force-dynamic';
+
 import { useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { ArrowRight, Clock, Loader2, MailQuestion, Sparkles, Users, XCircle } from 'lucide-react';

--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+// Next.js 15 prerender rejects `useSearchParams()` in a Client Component
+// unless wrapped in <Suspense>. Reset-password depends on URL params and
+// runs only after auth callback, so skip static prerender.
+export const dynamic = 'force-dynamic';
+
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ArrowRight, CheckCircle2, Loader2, Sparkles } from 'lucide-react';


### PR DESCRIPTION
Netlify build fails on `/callback-magic` because Next.js 15 needs `useSearchParams()` Client Components to be wrapped in `<Suspense>` for static prerender. Same risk on `/login` and `/reset-password`. Adding `export const dynamic = 'force-dynamic'` skips prerender — these pages always run dynamically anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)