### PR TITLE
fix(web): wrap auth pages in Suspense for Next.js 15 prerender

### DIFF
--- a/apps/web/src/app/(auth)/callback-magic/page.tsx
+++ b/apps/web/src/app/(auth)/callback-magic/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-// Next.js 15 prerender rejects `useSearchParams()` in a Client Component
-// unless wrapped in <Suspense>. This callback depends on URL hash + search
-// params and always runs in the browser, so skip static prerender entirely.
-export const dynamic = 'force-dynamic';
-
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '../../../lib/supabase/client';
 import { getMe } from '../../../lib/api/me';
@@ -22,7 +17,7 @@ function safeNext(raw: string | null): string {
 // Handles Supabase implicit-flow invite/magic links where tokens arrive as URL fragments
 // (#access_token=...). Server-side route handlers cannot read fragments, so this client
 // component reads them, calls setSession(), then redirects to ?next= (or /associations).
-export default function MagicLinkCallbackPage() {
+function MagicLinkCallbackInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -83,5 +78,23 @@ export default function MagicLinkCallbackPage() {
     <div className="flex min-h-screen items-center justify-center">
       <p className="text-sm text-muted-foreground">Giriş yapılıyor…</p>
     </div>
+  );
+}
+
+// Next.js 15 requires <Suspense> around any client component that reads
+// useSearchParams() — otherwise the prerender step bails out and fails
+// the build. Wrap the inner component so the same loading UI shows during
+// the brief client hydration window.
+export default function MagicLinkCallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <p className="text-sm text-muted-foreground">Giriş yapılıyor…</p>
+        </div>
+      }
+    >
+      <MagicLinkCallbackInner />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-// Next.js 15 prerender rejects `useSearchParams()` in a Client Component
-// unless wrapped in <Suspense>. Login reads `?error=` and `?next=` from
-// the URL, so skip static prerender entirely.
-export const dynamic = 'force-dynamic';
-
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { ArrowRight, Clock, Loader2, MailQuestion, Sparkles, Users, XCircle } from 'lucide-react';
 import { createClient } from '../../../lib/supabase/client';
@@ -32,7 +27,24 @@ import {
 import { Plus } from 'lucide-react';
 import { getProvinceNames, getDistricts } from '@/lib/turkey-locations';
 
+// Next.js 15 requires <Suspense> around any client component that reads
+// useSearchParams() — otherwise the prerender step bails out and fails
+// the build.
 export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      <LoginInner />
+    </Suspense>
+  );
+}
+
+function LoginInner() {
   const searchParams = useSearchParams();
   const callbackError = searchParams.get('error');
   const [branchDialogOpen, setBranchDialogOpen] = useState(false);

--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-// Next.js 15 prerender rejects `useSearchParams()` in a Client Component
-// unless wrapped in <Suspense>. Reset-password depends on URL params and
-// runs only after auth callback, so skip static prerender.
-export const dynamic = 'force-dynamic';
-
-import { useState, useEffect } from 'react';
+import { Suspense, useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ArrowRight, CheckCircle2, Loader2, Sparkles } from 'lucide-react';
 import { createClient } from '../../../lib/supabase/client';
@@ -23,7 +18,7 @@ function safeNext(raw: string | null, fallback: string): string {
   return raw;
 }
 
-export default function ResetPasswordPage() {
+function ResetPasswordInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   // Magic-link first-time set lands with ?next=/onboarding. Standalone
@@ -189,6 +184,23 @@ export default function ResetPasswordPage() {
         </footer>
       </div>
     </div>
+  );
+}
+
+// Next.js 15 requires <Suspense> around any client component that reads
+// useSearchParams() — otherwise the prerender step bails out and fails
+// the build.
+export default function ResetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      <ResetPasswordInner />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
force-dynamic is not enough in Next.js 15.5 — prerender still bails on useSearchParams() without <Suspense>. Refactor 3 auth pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)