### PR TITLE
chore(health): add timing + /ping for latency diagnostics

### DIFF
--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -8,12 +8,25 @@ export class HealthController {
   @Get()
   @HttpCode(200)
   async check() {
+    const start = Date.now();
     const timestamp = new Date().toISOString();
     try {
+      const dbStart = Date.now();
       await this.prisma.$queryRaw`SELECT 1`;
-      return { status: 'ok', timestamp, db: 'up' };
+      const dbMs = Date.now() - dbStart;
+      const totalMs = Date.now() - start;
+      return { status: 'ok', timestamp, db: 'up', dbMs, totalMs };
     } catch {
       return { status: 'degraded', timestamp, db: 'down' };
     }
+  }
+
+  // /ping does NOT touch the DB. If curl shows it returning fast but
+  // /health shows full latency, the cost is in the DB roundtrip.
+  // If both are slow, the cost is in Railway routing/edge.
+  @Get('ping')
+  @HttpCode(200)
+  ping() {
+    return { ok: true, t: Date.now() };
   }
 }


### PR DESCRIPTION
Diagnostic endpoints to isolate the 1.4s baseline on Railway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)